### PR TITLE
Bump SZ3 to v3.2.1 + add support for NoPrediction and Lossless compression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sz3"
-version = "0.1.1+SZ3-3.1.8.1"
+version = "0.2.0+SZ3-3.2.1"
 edition = "2021"
 authors = ["Robin Ole Heinemann <robin.ole.heinemann@gmail.com>"]
 description = "High level bindings to the SZ3 lossy floating point compressor."
@@ -16,7 +16,7 @@ exclude = ["test_data/*"]
 openmp = ["sz3-sys/openmp"]
 
 [dependencies]
-sz3-sys = { path = "sz3-sys", version = "0.1.1" }
+sz3-sys = { path = "sz3-sys", version = "0.2.0" }
 thiserror = "1.0.61"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sz3"
-version = "0.1.0+SZ3-3.1.8"
+version = "0.1.1+SZ3-3.1.8.1"
 edition = "2021"
 authors = ["Robin Ole Heinemann <robin.ole.heinemann@gmail.com>"]
 description = "High level bindings to the SZ3 lossy floating point compressor."
@@ -16,7 +16,7 @@ exclude = ["test_data/*"]
 openmp = ["sz3-sys/openmp"]
 
 [dependencies]
-sz3-sys = { path = "sz3-sys", version = "0.1.0" }
+sz3-sys = { path = "sz3-sys", version = "0.1.1" }
 thiserror = "1.0.61"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,7 @@
 #[derive(Clone, Debug, Copy)]
 pub enum CompressionAlgorithm {
-    Interpolation {
-        interp_block_size: u32,
-    },
-    InterpolationLorenzo {
-        interp_block_size: u32,
-    },
+    Interpolation,
+    InterpolationLorenzo,
     LorenzoRegression {
         lorenzo: bool,
         lorenzo_second_order: bool,
@@ -18,12 +14,8 @@ pub enum CompressionAlgorithm {
 impl CompressionAlgorithm {
     fn decode(config: sz3_sys::SZ3_Config) -> Self {
         match config.cmprAlgo as _ {
-            sz3_sys::SZ3_ALGO_ALGO_INTERP => Self::Interpolation {
-                interp_block_size: config.interpBlockSize as _,
-            },
-            sz3_sys::SZ3_ALGO_ALGO_INTERP_LORENZO => Self::InterpolationLorenzo {
-                interp_block_size: config.interpBlockSize as _,
-            },
+            sz3_sys::SZ3_ALGO_ALGO_INTERP => Self::Interpolation,
+            sz3_sys::SZ3_ALGO_ALGO_INTERP_LORENZO => Self::InterpolationLorenzo,
             sz3_sys::SZ3_ALGO_ALGO_LORENZO_REG => Self::LorenzoRegression {
                 lorenzo: config.lorenzo,
                 lorenzo_second_order: config.lorenzo2,
@@ -41,14 +33,6 @@ impl CompressionAlgorithm {
             Self::InterpolationLorenzo { .. } => sz3_sys::SZ3_ALGO_ALGO_INTERP_LORENZO,
             Self::LorenzoRegression { .. } => sz3_sys::SZ3_ALGO_ALGO_LORENZO_REG,
         }) as _
-    }
-
-    fn interp_block_size(&self) -> u32 {
-        match self {
-            Self::Interpolation { interp_block_size }
-            | Self::InterpolationLorenzo { interp_block_size } => *interp_block_size,
-            _ => 32,
-        }
     }
 
     fn lorenzo(&self) -> bool {
@@ -97,26 +81,6 @@ impl CompressionAlgorithm {
         }
     }
 
-    pub fn interpolation() -> Self {
-        Self::Interpolation {
-            interp_block_size: 32,
-        }
-    }
-
-    pub fn interpolation_custom(interp_block_size: u32) -> Self {
-        Self::Interpolation { interp_block_size }
-    }
-
-    pub fn interpolation_lorenzo() -> Self {
-        Self::InterpolationLorenzo {
-            interp_block_size: 32,
-        }
-    }
-
-    pub fn interpolation_lorenzo_custom(interp_block_size: u32) -> Self {
-        Self::InterpolationLorenzo { interp_block_size }
-    }
-
     pub fn lorenzo_regression() -> Self {
         Self::LorenzoRegression {
             lorenzo: true,
@@ -156,7 +120,7 @@ impl CompressionAlgorithm {
 
 impl Default for CompressionAlgorithm {
     fn default() -> Self {
-        CompressionAlgorithm::interpolation_lorenzo()
+        CompressionAlgorithm::InterpolationLorenzo
     }
 }
 
@@ -738,7 +702,6 @@ pub fn compress_with_config<V: SZ3Compressible>(
         lorenzo2: config.compression_algorithm.lorenzo_second_order(),
         regression: config.compression_algorithm.regression(),
         regression2: config.compression_algorithm.regression_second_order(),
-        interpBlockSize: config.compression_algorithm.interp_block_size() as _,
         pred_dim: config
             .compression_algorithm
             .encode_prediction_dimension(data.dims().len() as _) as _,
@@ -996,10 +959,8 @@ mod tests {
             })
         ],
         ([
-            (interpolation, CompressionAlgorithm::interpolation()),
-            (interpolation_8, CompressionAlgorithm::interpolation_custom(8)),
-            (interpolation_lorenzo, CompressionAlgorithm::interpolation_lorenzo()),
-            (interpolation_lorenzo_8, CompressionAlgorithm::interpolation_lorenzo_custom(8)),
+            (interpolation, CompressionAlgorithm::Interpolation),
+            (interpolation_lorenzo, CompressionAlgorithm::InterpolationLorenzo),
             (lorenzo_reg, CompressionAlgorithm::lorenzo_regression()),
             (lorenzo_reg_all, CompressionAlgorithm::lorenzo_regression_custom(
                 Some(true),

--- a/sz3-sys/Cargo.toml
+++ b/sz3-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sz3-sys"
-version = "0.1.0+SZ3-3.1.8"
+version = "0.1.1+SZ3-3.1.8.1"
 edition = "2021"
 license = "GPL-3.0-only"
 authors = ["Robin Ole Heinemann <robin.ole.heinemann@gmail.com>"]

--- a/sz3-sys/Cargo.toml
+++ b/sz3-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sz3-sys"
-version = "0.1.1+SZ3-3.1.8.1"
+version = "0.2.0+SZ3-3.2.1"
 edition = "2021"
 license = "GPL-3.0-only"
 authors = ["Robin Ole Heinemann <robin.ole.heinemann@gmail.com>"]

--- a/sz3-sys/wrapper.hpp
+++ b/sz3-sys/wrapper.hpp
@@ -18,7 +18,6 @@ struct SZ3_Config {
     uint8_t lossless;
     uint8_t encoder;
     uint8_t interpAlgo;
-    int interpBlockSize;
     int quantbinCnt;
     int blockSize;
     int stride;
@@ -43,7 +42,6 @@ struct SZ3_Config {
         conf.lossless = lossless;
         conf.encoder = encoder;
         conf.interpAlgo = interpAlgo;
-        conf.interpBlockSize = interpBlockSize;
         conf.quantbinCnt = quantbinCnt;
         conf.blockSize = blockSize;
         conf.stride = stride;
@@ -70,7 +68,6 @@ struct SZ3_Config {
         lossless = conf.lossless;
         encoder = conf.encoder;
         interpAlgo = conf.interpAlgo;
-        interpBlockSize = conf.interpBlockSize;
         quantbinCnt = conf.quantbinCnt;
         blockSize = conf.blockSize;
         stride = conf.stride;


### PR DESCRIPTION
The `ALGO_NOPRED` and `ALGO_LOSSLESS` compression modes are, granted, not very useful in most circumstances. Lossless just runs the lossless stage on the data, and no prediction only runs the quantizer + encoder + lossless stages. I'd like to just use SZ3's (prediction) error encoding, for which the no prediction mode is perfect.

If the PR looks good to you @rroohhh, perhaps you could also publish a new release (which then also includes the SZ3 v3.2.1 bump)?